### PR TITLE
修改 ngx.location.capture 链接错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ Mixing with SSI Not Supported
 SPDY Mode Not Fully Supported
 -----------------------------
 
-一些 ngx_lua 提供的 Lua APIs 在 Nginx 的`SPDY`模式下确定不能工作：ngx.location.capture](#ngxlocationcapture)， [ngx.location.capture_multi](#ngxlocationcapture_multi) 和 [ngx.req.socket](#ngxreqsocket)。
+一些 ngx_lua 提供的 Lua APIs 在 Nginx 的`SPDY`模式下确定不能工作：[ngx.location.capture](#ngxlocationcapture)， [ngx.location.capture_multi](#ngxlocationcapture_multi) 和 [ngx.req.socket](#ngxreqsocket)。
 
 [返回目录](#table-of-contents)
 


### PR DESCRIPTION
在 Known Issues -> SPDY Mode Not Fully Supported 章节中
对 ngx.location.capture 链接无法点击显示异常的问题进行修复